### PR TITLE
Replace ioutil.ReadAll with io.Copy

### DIFF
--- a/persistent/b2.go
+++ b/persistent/b2.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -89,13 +89,14 @@ func (b *b2) Get(ctx context.Context, key string) ([]byte, error) {
 		return nil, fmt.Errorf("storage: unexpected response status: %v", resp.Status)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data := &bytes.Buffer{}
+	_, err = io.Copy(data, resp.Body)
 	if err != nil {
 		B2Ops.WithLabelValues("get", "false").Inc()
 		return nil, err
 	}
 	B2Ops.WithLabelValues("get", "true").Inc()
-	return data, nil
+	return data.Bytes(), nil
 }
 
 func (b *b2) Set(ctx context.Context, key string, data []byte, _ DataType) error {

--- a/persistent/gcs.go
+++ b/persistent/gcs.go
@@ -1,8 +1,9 @@
 package persistent
 
 import (
+	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"cloud.google.com/go/storage"
@@ -53,13 +54,14 @@ func (g *gcs) Get(ctx context.Context, key string) ([]byte, error) {
 	}
 	defer r.Close()
 
-	data, err := ioutil.ReadAll(r)
+	data := &bytes.Buffer{}
+	_, err = io.Copy(data, r)
 	if err != nil {
 		GCSOps.WithLabelValues("get", "false").Inc()
 		return nil, err
 	}
 	GCSOps.WithLabelValues("get", "true").Inc()
-	return data, nil
+	return data.Bytes(), nil
 }
 
 func (g *gcs) Set(ctx context.Context, key string, data []byte, _ DataType) error {


### PR DESCRIPTION
ioutil.ReadAll is inefficient for large readers since it loads everything in memory. io.Copy uses fixed 32KB buffer to copy from reader to writer, so no matter how big the source is, it’ll always just use 32KB to copy it to destination.