### PR TITLE
Add support for different signing region and versions

### DIFF
--- a/cmd/internal/config/config.go
+++ b/cmd/internal/config/config.go
@@ -35,6 +35,8 @@ type StorageProvider struct {
 	S3Bucket string `yaml:"s3-bucket"`
 	S3Url    string `yaml:"s3-url"`
 	S3Region string `yaml:"s3-region"`
+	S3SigningRegion string `yaml:"s3-signing-region"` // Default to same as region
+	S3SigningVersion string `yaml:"s3-signing-version"` // Default "v4"
 
 	// Google Cloud Storage
 	GCSBucketName      string `yaml:"gcs-bucket-name"`
@@ -93,7 +95,13 @@ func (sp *StorageProvider) Store() (persistent.ObjectStorage, error) {
 	if sp.hasB2() {
 		out, err = persistent.NewB2(sp.B2AcctId, sp.B2AppKey, sp.B2Bucket, sp.B2Url)
 	} else if sp.hasS3() {
-		out, err = persistent.NewS3(sp.S3AppId, sp.S3AppKey, sp.S3Bucket, sp.S3Url, sp.S3Region)
+		if sp.S3SigningVersion == "" {
+			sp.S3SigningVersion = "v4"
+		}
+		if sp.S3SigningRegion == "" {
+			sp.S3SigningRegion = sp.S3Region
+		}
+		out, err = persistent.NewS3(sp.S3AppId, sp.S3AppKey, sp.S3Bucket, sp.S3Url, sp.S3Region, sp.S3SigningRegion, sp.S3SigningVersion)
 	} else if sp.hasGCS() {
 		out, err = persistent.NewGCS(sp.GCSBucketName, sp.GCSCredentialsPath)
 	} else if sp.hasDisk() {


### PR DESCRIPTION
Fixes #33 

Hi all,

I've put together a fix that makes utahfs work with idrive.com

It works for me. An example config is below:

```
storage-provider:
  s3-app-id: the-app-id
  s3-app-key: the-key
  s3-bucket: the-bucket-name
  s3-url: https://s3.us-west-1.idrivecloud.io
  s3-region: us-west-1
  s3-signing-region: us-east-1
  s3-signing-version: v2
  # # Alternatively, remove the above s3-* keys and setup Backblaze B2 access:
  # b2-acct-id:
  # b2-app-key:
  # b2-bucket:
  # b2-url:
  # # Or finally, use GCS:
  # gcs-bucket-name:

keep-metadata: true

password: the-password
# archive: true
# oram: true
```