### PR TITLE
Update bucket setup instruction

### DIFF
--- a/docs/setup-backblaze-b2.md
+++ b/docs/setup-backblaze-b2.md
@@ -8,8 +8,7 @@ Setup Backblaze B2
 3. Create a bucket. The bucket should be public and be named the random
    string you generated above; also set the random string as `b2-bucket` in
    your config.
-4. Click on "Lifecycle Settings", choose "Keep prior versions for 7 days",
-   submit.
+4. Enable "Default Encryption", disable "Object Lock" and Submit.
 5. Click "App Keys" in the sidebar. Save the keyID for "Master Application Key"
    as `b2-acct-id` in your config. Select "Generate New Master Application Key"
    (or use the one you already know) and save the application key as


### PR DESCRIPTION
The [backblaze b2 instructions](https://github.com/cloudflare/utahfs/blob/master/docs/setup-backblaze-b2.md) seem to be outdated:
* "Lifecycle Settings" and "Keep prior versions for 7 days" are no longer part of the backblaze bucket setup.
* Instead "Default Encryption" and "Object Lock" have to be set.

Disclaimer: I'm not entirely sure if the values I've written in are correct.