### PR TITLE
Add support for non-master B2 keys

### DIFF
--- a/cmd/internal/config/config.go
+++ b/cmd/internal/config/config.go
@@ -25,6 +25,7 @@ func maxSize(numPtrs, dataSize int64) int64 {
 type StorageProvider struct {
 	// Backblaze B2
 	B2AcctId string `yaml:"b2-acct-id"`
+	B2KeyId  string `yaml:"b2-key-id"`
 	B2AppKey string `yaml:"b2-app-key"`
 	B2Bucket string `yaml:"b2-bucket"`
 	B2Url    string `yaml:"b2-url"`
@@ -91,7 +92,7 @@ func (sp *StorageProvider) Store() (persistent.ObjectStorage, error) {
 		err error
 	)
 	if sp.hasB2() {
-		out, err = persistent.NewB2(sp.B2AcctId, sp.B2AppKey, sp.B2Bucket, sp.B2Url)
+		out, err = persistent.NewB2(sp.B2AcctId, sp.B2KeyId, sp.B2AppKey, sp.B2Bucket, sp.B2Url)
 	} else if sp.hasS3() {
 		out, err = persistent.NewS3(sp.S3AppId, sp.S3AppKey, sp.S3Bucket, sp.S3Url, sp.S3Region)
 	} else if sp.hasGCS() {

--- a/docs/setup-backblaze-b2.md
+++ b/docs/setup-backblaze-b2.md
@@ -12,7 +12,9 @@ Setup Backblaze B2
 5. Click "App Keys" in the sidebar. Save the keyID for "Master Application Key"
    as `b2-acct-id` in your config. Select "Generate New Master Application Key"
    (or use the one you already know) and save the application key as
-   `b2-app-key` in your config.
+   `b2-app-key` in your config. Keys other than the master key can be used by
+   creating a regular application key and setting the `b2-key-id` field in the
+   config _instead of the `b2-app-key` field_.
 6. Click on "Browse Files", click on your bucket, upload some file. Click on
    the file to bring up the info prompt. Take the "Friendly URL" and remove
    the filename from the end and the trailing slash. It should end with the

--- a/persistent/b2.go
+++ b/persistent/b2.go
@@ -47,14 +47,23 @@ type b2 struct {
 
 // NewB2 returns object storage backed by Backblaze B2. `acctId` and `appKey`
 // are the Account ID and Application Key of a B2 bucket. `bucketName` is the
-// name of the bucket. `url` is the URL to use to download data.
-func NewB2(acctId, appKey, bucketName, url string) (ObjectStorage, error) {
+// name of the bucket. `url` is the URL to use to download data. Keys other than
+// the master key can be used by omitting the account key and providing the key
+// ID provided by B2 with the key.
+func NewB2(acctId, keyId, appKey, bucketName, url string) (ObjectStorage, error) {
+	creds := backblaze.Credentials{
+		AccountID:      acctId,
+		ApplicationKey: appKey,
+		KeyID:          keyId,
+	}
+
+	if acctId != "" {
+		creds.KeyID = ""
+	}
+
 	pool := &sync.Pool{
 		New: func() interface{} {
-			conn, err := backblaze.NewB2(backblaze.Credentials{
-				AccountID:      acctId,
-				ApplicationKey: appKey,
-			})
+			conn, err := backblaze.NewB2(creds)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Currently only master keys are supported that provide unrestricted access to all buckets on the account. Application keys need to be identified by a key specific ID that the current configuration doesn't support setting. The implementation tracks the [behavior of the client library](https://pkg.go.dev/gopkg.in/kothar/go-backblaze.v0?utm_source=godoc#Credentials) preferring the account id if both are provided.

> If using the master application key, leave this set to an empty string as your account id will be used instead.
> godoc

